### PR TITLE
Added support for output descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "amplify"
+version = "3.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ec14f4fb838e9ddace42fa5944bb1ee4dff8477494ba48c5f874e16caf27a"
+dependencies = [
+ "amplify_derive",
+ "amplify_num",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_derive"
+version = "2.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c3de270e75f27a4468a7c344070109046656e85cb522141f7d40ab4b83803ac"
+dependencies = [
+ "amplify_syn",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "amplify_num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27d3d00d3d115395a7a8a4dc045feb7aa82b641e485f7e15f4e67ac16f4f56d"
+
+[[package]]
+name = "amplify_syn"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da24db1445cc7bc3842fa072c2d51fe5b25b812b6a572d65842a4c72e87221ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "argfile"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +539,7 @@ dependencies = [
  "kv",
  "log",
  "miniscript",
+ "pretty_assertions",
  "pretty_env_logger",
  "rand",
  "rmp-serde",
@@ -501,6 +548,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "signal-hook",
+ "slip132",
  "toml",
 ]
 
@@ -989,9 +1037,8 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniscript"
-version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9601439f168c13bdc5bf84349c2e61c815be4a4dcebe8c4ff4af58f4e8a6d20"
+version = "9.0.0"
+source = "git+https://github.com/douglaz/rust-miniscript.git?branch=master-2023-03-30#4a3ba11c2fd5063be960741d557f3f7a28041e1f"
 dependencies = [
  "bitcoin",
 ]
@@ -1116,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1276,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -1589,6 +1657,16 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "slip132"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a2947cb179006a73896fca01015ee5255c05b8b83e74c5e9d623ed4480abe2"
+dependencies = [
+ "amplify",
+ "bitcoin",
 ]
 
 [[package]]
@@ -2055,3 +2133,9 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 kv = "0.24.0"
-miniscript = "9.0.0"
+# Using master branch of miniscript because the multipath feature for output descriptor parsing isn't released yet
+miniscript = { git = "https://github.com/douglaz/rust-miniscript.git", branch = "master-2023-03-30" }
 pretty_env_logger = "0.4.0"
 futures = "0.3.4"
 rmp-serde = { optional = true, version = "1.1.1" }
@@ -23,6 +24,10 @@ dirs = "4.0.0"
 signal-hook = "0.3.14"
 rand = "0.8.5"
 bitcoin = { version = "0.29", features = ["serde", "std", "bitcoinconsensus"] }
+slip132 = "0.9.0"
+
+[dev-dependencies]
+pretty_assertions = "1"
 
 [features]
 default = ["experimental-p2p"]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,3 +1,4 @@
 [wallet]
 xpubs = []
+descriptors = []
 addresses = []

--- a/docs/tutorial(PT-BR).md
+++ b/docs/tutorial(PT-BR).md
@@ -39,7 +39,11 @@ se tudo estiver ok, irá compilar o programa e salvar o executável em `./target
 
 Antes de rodar ele pela primeira vez, você precisa extrair a xpub da sua carteira. Na Electrum, basta ir no menu "Carteira" e clicar em "Informações", a xpub vai aparecer em uma caixa de texto grande.
 
-Uma vez que você tenha a Chave Pública Extendida em mãos, copie o arquivo de configuração `config.toml.sample` para `config.toml` edite-o inserindo a xpub no campo apropriado. Você pode inserir infinitas xpubs. Também é permitido endereços soltos. No momento, esse software não suporta multisig, você precisa passar os endereços do multisig manualmente. Veja [abaixo](#config_example) um exemplo de arquivo válido.
+Uma vez que você tenha a Chave Pública Extendida em mãos, copie o arquivo de configuração `config.toml.sample` para `config.toml` edite-o inserindo a xpub no campo apropriado. Você pode inserir infinitas xpubs. Também é permitido endereços soltos.
+
+Para endereços multisig, uma carteira como Sparrow é recomendada. Basta copiar o "output descriptor" gerado pela mesma.
+
+Veja [abaixo](#config_example) um exemplo de arquivo válido.
 
 ```bash
 floresta -c config.toml --network signet run
@@ -76,6 +80,9 @@ xpubs = [
 ]
 addresses = [
     "tb1qjfplwf7a2dpjj04cx96rysqeastvycc0j50cch"
+]
+descriptors = [
+    "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q"
 ]
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,8 @@ pub enum Commands {
         /// Add a xpub to our wallet
         #[arg(long)]
         wallet_xpub: Option<Vec<String>>,
+        #[arg(long)]
+        wallet_descriptor: Option<Vec<String>>,
         /// Assume blocks before this one as having valid signatures, same with bitcoin core
         #[arg(long)]
         assume_valid: Option<BlockHash>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,9 @@ pub enum Error {
     ChainError(BlockchainError),
     SerdeJsonError(serde_json::Error),
     TomlParsingError(toml::de::Error),
-    WalletInputError(crate::wallet_input::ParsingError),
+    WalletInputError(slip132::Error),
     AddressParsingError(bitcoin::util::address::Error),
+    MiniscriptError(miniscript::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -39,6 +40,7 @@ impl std::fmt::Display for Error {
             Error::WalletInputError(err) => write!(f, "Error while parsing user input {:?}", err),
             Error::TomlParsingError(err) => write!(f, "Error deserializing toml file {err}"),
             Error::AddressParsingError(err) => write!(f, "Invalid address {err}"),
+            Error::MiniscriptError(err) => write!(f, "Miniscript error: {err}"),
         }
     }
 }
@@ -54,9 +56,10 @@ impl_from_error!(IoError, std::io::Error);
 impl_from_error!(ValidationError, bitcoin::blockdata::script::Error);
 impl_from_error!(ChainError, BlockchainError);
 impl_from_error!(SerdeJsonError, serde_json::Error);
-impl_from_error!(WalletInputError, crate::wallet_input::ParsingError);
+impl_from_error!(WalletInputError, slip132::Error);
 impl_from_error!(TomlParsingError, toml::de::Error);
 impl_from_error!(AddressParsingError, bitcoin::util::address::Error);
+impl_from_error!(MiniscriptError, miniscript::Error);
 
 impl std::error::Error for Error {}
 #[macro_export]

--- a/src/wallet_input.rs
+++ b/src/wallet_input.rs
@@ -2,95 +2,102 @@
 //! Handles different inputs, try to make sense out of it and store a sane descriptor at the end
 //!
 
-use std::array::TryFromSliceError;
+use std::str::FromStr;
 
-use bitcoin::util::base58;
-#[derive(Debug)]
-pub enum ParsingError {
-    UnknownVersion([u8; 4]),
-    InvalidBase68CheckString(base58::Error),
-    InvalidSlice(TryFromSliceError),
-    InvalidSize(usize),
-}
-impl From<base58::Error> for ParsingError {
-    fn from(err: base58::Error) -> Self {
-        Self::InvalidBase68CheckString(err)
-    }
-}
-impl From<TryFromSliceError> for ParsingError {
-    fn from(err: TryFromSliceError) -> Self {
-        Self::InvalidSlice(err)
-    }
-}
+use bitcoin::Address;
+use miniscript::{Descriptor, DescriptorPublicKey};
+
 pub mod extended_pub_key {
-    use bitcoin::{
-        util::{
-            base58,
-            bip32::{ChainCode, ExtendedPubKey, Fingerprint},
-        },
-        Network,
-    };
+    use bitcoin::util::bip32::ExtendedPubKey;
 
-    use super::ParsingError;
-    type Error = ParsingError;
-    fn get_network(version: [u8; 4]) -> Result<Network, Error> {
-        match version {
-            // Mainnet
-            // P2PKH or P2SH
-            [0x04, 0x88, 0xb2, 0x1e] => Ok(Network::Bitcoin),
-            // P2WPKH in P2SH
-            [0x04, 0x9d, 0x7c, 0xb2] => Ok(Network::Bitcoin),
-            // P2WPKH
-            [0x04, 0xb2, 0x47, 0x46] => Ok(Network::Bitcoin),
-            // Multi-signature P2WSH in P2SH
-            [0x02, 0x95, 0xb4, 0x3f] => Ok(Network::Bitcoin),
-            // Multi-signature P2WSH
-            [0x02, 0xaa, 0x7e, 0xd3] => Ok(Network::Bitcoin),
-
-            // Testnet
-            // P2PKH or P2SH
-            [0x04, 0x35, 0x87, 0xcf] => Ok(Network::Bitcoin),
-            // P2WPKH in P2SH
-            [0x04, 0x4a, 0x52, 0x62] => Ok(Network::Bitcoin),
-            // P2WPKH
-            [0x04, 0x5f, 0x1c, 0xf6] => Ok(Network::Bitcoin),
-            // Multi-signature P2WSH in P2SH
-            [0x02, 0x42, 0x89, 0xef] => Ok(Network::Bitcoin),
-            // Multi-signature P2WSH
-            [0x02, 0x57, 0x54, 0x83] => Ok(Network::Bitcoin),
-            _ => Err(Error::UnknownVersion(version)),
-        }
+    pub fn from_str(s: &str) -> Result<ExtendedPubKey, slip132::Error> {
+        slip132::FromSlip132::from_slip132_str(s)
     }
-    /// Decoding extended public key from binary data according to BIP 32
-    /// code partially copied from Rust-Bitcoin
-    fn decode_xpub(data: &[u8]) -> Result<ExtendedPubKey, Error> {
-        if data.len() != 78 {
-            return Err(Error::InvalidSize(data.len()));
-        }
-        let network = get_network(data[0..4].try_into()?)?;
+}
 
-        Ok(ExtendedPubKey {
-            network,
-            depth: data[4],
-            parent_fingerprint: Fingerprint::from(&data[5..9]),
-            child_number: bitcoin::util::bip32::ChildNumber::Normal { index: 0 }, //TODO
-            chain_code: ChainCode::from(&data[13..45]),
-            public_key: bitcoin::secp256k1::PublicKey::from_slice(&data[45..78]).expect("msg"),
+fn parse_xpubs(
+    xpubs: &[String],
+) -> Result<Vec<Descriptor<DescriptorPublicKey>>, crate::error::Error> {
+    let mut descriptors = Vec::new();
+    for key in xpubs {
+        // Parses the descriptor and get an external and change descriptors
+        let xpub = extended_pub_key::from_str(key.as_str()).map_err(|e| {
+            log::error!("Invalid xpub provided: {key} \nReason: {e:?}");
+            e
+        })?;
+        let main_desc = format!("wpkh({xpub}/0/*)");
+        let change_desc = format!("wpkh({xpub}/1/*)");
+        descriptors.push(Descriptor::<DescriptorPublicKey>::from_str(&main_desc)?);
+        descriptors.push(Descriptor::<DescriptorPublicKey>::from_str(&change_desc)?);
+    }
+    Ok(descriptors)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InitialWalletSetup {
+    pub(crate) descriptors: Vec<Descriptor<DescriptorPublicKey>>,
+    pub(crate) addresses: Vec<Address>,
+}
+
+impl InitialWalletSetup {
+    pub(crate) fn build(
+        xpubs: &[String],
+        initial_descriptors: &[String],
+        addresses: &[String],
+        network: bitcoin::Network,
+        addresses_per_descriptor: u32,
+    ) -> Result<Self, crate::error::Error> {
+        let mut descriptors = parse_xpubs(xpubs)?;
+        descriptors.extend(parse_descriptors(initial_descriptors)?);
+        descriptors.sort();
+        descriptors.dedup();
+        let mut addresses = addresses
+            .iter()
+            .map(|address| Address::from_str(address))
+            .collect::<Result<Vec<_>, _>>()?;
+        addresses.extend(descriptors.iter().flat_map(|descriptor| {
+            (0..addresses_per_descriptor).map(|index| {
+                descriptor
+                    .at_derivation_index(index)
+                    .expect("Error while deriving address")
+                    .address(network)
+                    .expect("Error while deriving address. Is this an active descriptor?")
+            })
+        }));
+        addresses.sort();
+        addresses.dedup();
+        Ok(Self {
+            descriptors,
+            addresses,
         })
     }
-    pub fn from_wif(wif: &str) -> Result<ExtendedPubKey, Error> {
-        let data = base58::from_check(wif)?;
-        decode_xpub(&data)
-    }
+}
+
+fn parse_descriptors(
+    descriptors: &[String],
+) -> Result<Vec<Descriptor<DescriptorPublicKey>>, crate::error::Error> {
+    let descriptors = descriptors
+        .iter()
+        .map(|descriptor| {
+            let descriptor = Descriptor::<DescriptorPublicKey>::from_str(descriptor.as_str())?;
+            descriptor.sanity_check()?;
+            descriptor.into_single_descriptors()
+        })
+        .collect::<Result<Vec<Vec<_>>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    Ok(descriptors)
 }
 
 #[cfg(test)]
 pub mod test {
+    use super::*;
     use bitcoin::{secp256k1::Secp256k1, util::bip32::ChildNumber};
     use bitcoin::{Address, Network};
 
     #[test]
-    fn test_parsing() {
+    fn test_xpub_parsing() {
         // Test cases from https://github.com/satoshilabs/slips/blob/master/slip-0132.md
         const XPUB: &str = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj";
         const YPUB: &str = "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP";
@@ -98,43 +105,30 @@ pub mod test {
 
         let secp = Secp256k1::new();
 
-        let xpub: bitcoin::util::bip32::ExtendedPubKey = super::extended_pub_key::from_wif(XPUB)
+        let xpub: bitcoin::util::bip32::ExtendedPubKey = super::extended_pub_key::from_str(XPUB)
             .expect("Parsing failed")
             .ckd_pub(&secp, ChildNumber::Normal { index: 0 })
             .and_then(|key| key.ckd_pub(&secp, ChildNumber::Normal { index: 0 }))
             .unwrap();
-        let first_pk = bitcoin::PublicKey {
-            compressed: true,
-            inner: xpub.public_key,
-        };
-        let ypub = super::extended_pub_key::from_wif(YPUB)
+        let ypub = super::extended_pub_key::from_str(YPUB)
             .expect("Parsing failed")
             .ckd_pub(&secp, ChildNumber::Normal { index: 0 })
             .and_then(|key| key.ckd_pub(&secp, ChildNumber::Normal { index: 0 }))
             .unwrap();
-        let second_pk = bitcoin::PublicKey {
-            compressed: true,
-            inner: ypub.public_key,
-        };
-
-        let zpub = super::extended_pub_key::from_wif(ZPUB)
+        let zpub = super::extended_pub_key::from_str(ZPUB)
             .expect("Parsing failed")
             .ckd_pub(&secp, ChildNumber::Normal { index: 0 })
             .and_then(|key| key.ckd_pub(&secp, ChildNumber::Normal { index: 0 }))
             .unwrap();
-        let third_pk = bitcoin::PublicKey {
-            compressed: true,
-            inner: zpub.public_key,
-        };
         // Old p2pkh
         assert_eq!(
-            Address::p2pkh(&first_pk, bitcoin::Network::Bitcoin)
+            Address::p2pkh(&xpub.to_pub(), bitcoin::Network::Bitcoin)
                 .to_string()
                 .as_str(),
             "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
         );
         // p2wpkh-p2pkh
-        let script = Address::p2wpkh(&second_pk, bitcoin::Network::Bitcoin)
+        let script = Address::p2wpkh(&ypub.to_pub(), bitcoin::Network::Bitcoin)
             .unwrap()
             .script_pubkey();
 
@@ -148,11 +142,113 @@ pub mod test {
 
         // p2wpkh
         assert_eq!(
-            Address::p2wpkh(&third_pk, bitcoin::Network::Bitcoin)
+            Address::p2wpkh(&zpub.to_pub(), bitcoin::Network::Bitcoin)
                 .unwrap()
                 .to_string()
                 .as_str(),
             "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
         )
+    }
+
+    #[test]
+    fn test_descriptor_parsing() {
+        // singlesig
+        assert_eq!(
+            parse_descriptors(&[
+                "wpkh([a5b13c0e/84h/0h/0h]xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)#n8sgapuv".to_owned()
+            ]).unwrap(),
+            parse_descriptors(&[
+                "wpkh([a5b13c0e/84'/0'/0']xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/0/*)#wg8dh3s7".to_owned(),
+                "wpkh([a5b13c0e/84'/0'/0']xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/1/*)#luzv2yqx".to_owned()
+            ]).unwrap()
+        );
+        // multisig
+        assert_eq!(
+            parse_descriptors(&[
+                "wsh(sortedmulti(1,[6f826a6a/48h/0h/0h/2h]xpub6DsY48BAsvEMTRPbeSTu9jZXqEsTKr5T86WbRbXHp2gEVCNR3hALnMorFawVwnnHMMfjbyY8We9B4beh1fxqhcv6kgSeLgQxeXDqv3DaW7m/<0;1>/*,[a5b13c0e/48h/0h/0h/2h]xpub6Eqj1Hj3RezebC6cKiYYN2sAc1Wu33BWoaafnNgAbQwDkJdy7aXCYCmaMzb8rCpmh919UsehyV5Ywjo62hG4R2G2PGv4uqEDTUhYQw26BDJ/<0;1>/*))#nykmcu2v".to_owned()
+            ]).unwrap(),
+            parse_descriptors(&[
+                "wsh(sortedmulti(1,[6f826a6a/48'/0'/0'/2']xpub6DsY48BAsvEMTRPbeSTu9jZXqEsTKr5T86WbRbXHp2gEVCNR3hALnMorFawVwnnHMMfjbyY8We9B4beh1fxqhcv6kgSeLgQxeXDqv3DaW7m/0/*,[a5b13c0e/48'/0'/0'/2']xpub6Eqj1Hj3RezebC6cKiYYN2sAc1Wu33BWoaafnNgAbQwDkJdy7aXCYCmaMzb8rCpmh919UsehyV5Ywjo62hG4R2G2PGv4uqEDTUhYQw26BDJ/0/*))#sw68w95x".to_owned(),
+                "wsh(sortedmulti(1,[6f826a6a/48'/0'/0'/2']xpub6DsY48BAsvEMTRPbeSTu9jZXqEsTKr5T86WbRbXHp2gEVCNR3hALnMorFawVwnnHMMfjbyY8We9B4beh1fxqhcv6kgSeLgQxeXDqv3DaW7m/1/*,[a5b13c0e/48'/0'/0'/2']xpub6Eqj1Hj3RezebC6cKiYYN2sAc1Wu33BWoaafnNgAbQwDkJdy7aXCYCmaMzb8rCpmh919UsehyV5Ywjo62hG4R2G2PGv4uqEDTUhYQw26BDJ/1/*))#fafrqkpn".to_owned()
+            ]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_initial_wallet_build() {
+        use pretty_assertions::assert_eq;
+        let addresses_per_descriptor = 1;
+        let network = Network::Bitcoin;
+        // Build wallet from xpub (in this case a zpub from slip132 standard)
+        let w1_xpub = InitialWalletSetup::build(&[
+            "zpub6qvVf5mN7DH14wr7oZS7xL6cpcFPDmxFEHBk18YpUF1qnroE1yGfW83eafbbi23dzRk7jrVXeJFMyCo3urmQpwkXtVnRmGmaJ3qVvdwx4mB".to_owned()
+        ], &[], &[], network, addresses_per_descriptor).unwrap();
+        // Build same wallet from output descriptor
+        let w1_descriptor = InitialWalletSetup::build(&[], &[
+            "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)".to_owned()
+        ], &[], network, addresses_per_descriptor).unwrap();
+        // Using both methods the result should be the same
+        assert_eq!(w1_xpub, w1_descriptor);
+        // Both normal receiving descriptor and change descriptor should be present
+        assert_eq!(
+            w1_descriptor.descriptors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec![
+                "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/0/*)#qua4l7ct",
+                "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/1/*)#3gc5ztgn"
+            ]
+        );
+        // Receiving and change addresses
+        let addresses = vec![
+            "bc1q88guum89mxwszau37m3y4p24renwlwgtkscl6x".to_owned(),
+            "bc1q24629yendf7q0dxnw362dqccn52vuz9s0z59hr".to_owned(),
+        ];
+        assert_eq!(
+            w1_descriptor
+                .addresses
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            addresses
+        );
+        // We can build from these addresses
+        let w1_addresses =
+            InitialWalletSetup::build(&[], &[], &addresses, network, addresses_per_descriptor)
+                .unwrap();
+        // And the result will be the same as from xpub/descriptor
+        assert_eq!(w1_descriptor.addresses, w1_addresses.addresses);
+        // We can also build from xpub, descriptor and addresses, at same time
+        let w1_all =
+            InitialWalletSetup::build(&[
+                "zpub6qvVf5mN7DH14wr7oZS7xL6cpcFPDmxFEHBk18YpUF1qnroE1yGfW83eafbbi23dzRk7jrVXeJFMyCo3urmQpwkXtVnRmGmaJ3qVvdwx4mB".to_owned()
+            ], &[
+                "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)".to_owned()
+            ], &addresses, network, addresses_per_descriptor).unwrap();
+        // And the result should be the same, no duplication will happen
+        assert_eq!(w1_descriptor, w1_all);
+    }
+
+    #[test]
+    fn test_initial_wallet_build_multisig_testnet() {
+        use pretty_assertions::assert_eq;
+        let addresses_per_descriptor = 1;
+        let network = Network::Testnet;
+        let w1_descriptor = InitialWalletSetup::build(&[], &[
+            "wsh(sortedmulti(1,[54ff5a12/48h/1h/0h/2h]tpubDDw6pwZA3hYxcSN32q7a5ynsKmWr4BbkBNHydHPKkM4BZwUfiK7tQ26h7USm8kA1E2FvCy7f7Er7QXKF8RNptATywydARtzgrxuPDwyYv4x/<0;1>/*,[bcf969c0/48h/1h/0h/2h]tpubDEFdgZdCPgQBTNtGj4h6AehK79Jm4LH54JrYBJjAtHMLEAth7LuY87awx9ZMiCURFzFWhxToRJK6xp39aqeJWrG5nuW3eBnXeMJcvDeDxfp/<0;1>/*))#fuw35j0q".to_owned()
+        ], &[], network, addresses_per_descriptor).unwrap();
+        let addresses = vec![
+            "tb1q2eeqw57e7pmrh5w3wkrshctx2qk80vf4mu7l7ek3ne4hg3lmcrnqcwejgj".to_owned(),
+            "tb1q6dpyc3jyqelgfwksedef0k2244rcg4gf6wvqm463lk907es2m08qnrfky7".to_owned(),
+        ];
+        assert_eq!(
+            w1_descriptor
+                .addresses
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            addresses
+        );
     }
 }


### PR DESCRIPTION
- Added support for output descriptors, including multisig
- Replaced xpub parsing with `slip132` crate because it was half-baked and messing up the correctness of the new tests