### PR TITLE
Derive more addresses as we get transactions

### DIFF
--- a/src/wallet_input.rs
+++ b/src/wallet_input.rs
@@ -73,7 +73,7 @@ impl InitialWalletSetup {
     }
 }
 
-fn parse_descriptors(
+pub fn parse_descriptors(
     descriptors: &[String],
 ) -> Result<Vec<Descriptor<DescriptorPublicKey>>, crate::error::Error> {
     let descriptors = descriptors


### PR DESCRIPTION
Until now, we only derived 100 addresses when we first get a descriptor, and never more. This commit allows generating more addresses after we receive 100 transactions.