### PR TITLE
Fix a bug with prot 70016

### DIFF
--- a/src/blockchain/error.rs
+++ b/src/blockchain/error.rs
@@ -38,6 +38,8 @@ pub enum BlockchainError {
     AddrParseError(std::net::AddrParseError),
     #[cfg(feature = "experimental-p2p")]
     PeerMisbehaving,
+    #[cfg(feature = "experimental-p2p")]
+    InvalidMessage(String),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
We would send SendAddrV2 after verack, this is a violation of the handshake, and causes remote peer to hang on us