### PR TITLE
Fix: return leaf_hashes

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -309,7 +309,7 @@ where
             .map(|hash| NodeHash::Some(hash.into_inner()))
             .collect();
         let proof = Proof::new(targets, hashes);
-        let hashes = Vec::new();
+        let mut hashes = Vec::new();
         let mut leaves_iter = udata.leaves.iter().cloned();
         let mut tx_iter = transactions.iter();
 
@@ -341,6 +341,7 @@ where
                         {
                             return Err(WireError::CoinbaseNotMatured);
                         }
+                        hashes.push(leaf._get_leaf_hashes());
                         inputs.insert(leaf.prevout, leaf.utxo);
                     }
                 }


### PR DESCRIPTION
In some previous iteration, the leaf_hashes wasn't being returned, and therefore, no proof verification was actually happening.