### PR TITLE
Make peer generic over transport

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1074,8 +1074,8 @@ impl Decodable for BestChain {
 #[cfg(test)]
 mod test {
     extern crate std;
-    use crate::Network;
     use crate::{prelude::HashMap, pruned_utreexo::consensus::Consensus};
+    use crate::{KvChainStore, Network};
     use bitcoin::{
         consensus::{deserialize, Decodable},
         hashes::hex::FromHex,
@@ -1085,9 +1085,7 @@ mod test {
     use std::io::Cursor;
     use std::{format, vec::Vec};
 
-    use super::{
-        BlockchainInterface, ChainParams, DiskBlockHeader, KvChainStore, UpdatableChainstate,
-    };
+    use super::{BlockchainInterface, ChainParams, DiskBlockHeader, UpdatableChainstate};
 
     use super::ChainState;
     #[test]

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
@@ -77,6 +78,12 @@ impl From<AddrV2Message> for LocalAddress {
             id: rand::random::<usize>(),
         }
     }
+}
+impl FromStr for LocalAddress {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        LocalAddress::try_from(s)
+    }
+    type Err = std::net::AddrParseError;
 }
 impl TryFrom<&str> for LocalAddress {
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -7,4 +7,5 @@ pub mod node;
 pub mod node_context;
 pub mod node_interface;
 pub mod peer;
+pub mod socks;
 pub mod stream_reader;

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -13,6 +13,7 @@ use super::{
 use async_std::{
     channel::{self, bounded, Receiver, SendError, Sender},
     future::timeout,
+    net::TcpStream,
     sync::RwLock,
     task::spawn,
 };
@@ -623,7 +624,7 @@ where
     }
     async fn open_connection(&mut self, feeler: bool, peer_id: usize, address: LocalAddress) {
         let (requests_tx, requests_rx) = bounded(1024);
-        spawn(Peer::create_outbound_connection(
+        spawn(Peer::<TcpStream>::create_outbound_connection(
             self.peer_id_count,
             (address.get_net_address(), address.get_port()),
             self.mempool.clone(),

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -318,6 +318,40 @@ impl<T: Transport> Peer<T> {
         Ok(())
     }
     #[allow(clippy::too_many_arguments)]
+    pub fn create_peer_from_transport(
+        stream: T,
+        id: u32,
+        mempool: Arc<RwLock<Mempool>>,
+        network: Network,
+        node_tx: Sender<NodeNotification>,
+        node_requests: Receiver<NodeRequest>,
+        address_id: usize,
+        feeler: bool,
+    ) {
+        let peer = Peer {
+            address_id,
+            blocks_only: false,
+            current_best_block: -1,
+            id,
+            mempool,
+            last_ping: Instant::now(),
+            network,
+            node_tx,
+            services: ServiceFlags::NONE,
+            stream,
+            messages: 0,
+            start_time: Instant::now(),
+            user_agent: "".into(),
+            state: State::None,
+            send_headers: false,
+            node_requests,
+            feeler,
+            wants_addrv2: false,
+        };
+        spawn(peer.read_loop());
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_outbound_connection<A: ToSocketAddrs>(
         id: u32,
         address: A,

--- a/crates/floresta-wire/src/p2p_wire/socks.rs
+++ b/crates/floresta-wire/src/p2p_wire/socks.rs
@@ -1,0 +1,127 @@
+//! A wrapper around a TCP stream that handles the SOCKS5 handshake. This module only
+//! drives the handshake and returns the stream back to the caller. It does not
+//! perform any I/O on the stream after the handshake is complete. The caller is
+//! responsible for performing I/O on the stream.
+//! This module is built on top of the `futures` crate instead of an specific
+//! async runtime. This allows the caller to use this module with any async runtime
+//! they want.
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+#[derive(Clone, Debug)]
+pub struct Socks5StreamBuilder {
+    pub address: SocketAddr,
+}
+/// The version of the SOCKS protocol we support, only SOCKS5 is supported.
+const SOCKS_VERSION: u8 = 5;
+/// The SOCKS authentication method we support, only no authentication is supported.
+const SOCKS_AUTH_METHOD_NONE: u8 = 0;
+/// The cmd value for a SOCKS5 connect request.
+const SOCKS_CMD_CONNECT: u8 = 1;
+/// Magic value to indicate an IPv4 address.
+const SOCKS_ADDR_TYPE_IPV4: u8 = 1;
+/// Magic value to indicate a domain address.
+const SOCKS_ADDR_TYPE_DOMAIN: u8 = 3;
+/// Magic value to indicate an IPv6 address.
+const SOCKS_ADDR_TYPE_IPV6: u8 = 4;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum Socks5Addr {
+    Ipv4(Ipv4Addr),
+    Ipv6(Ipv6Addr),
+    Domain(String),
+}
+impl From<Socks5Addr> for u8 {
+    fn from(val: Socks5Addr) -> Self {
+        match val {
+            Socks5Addr::Ipv4(_) => SOCKS_ADDR_TYPE_IPV4,
+            Socks5Addr::Ipv6(_) => SOCKS_ADDR_TYPE_IPV6,
+            Socks5Addr::Domain(_) => SOCKS_ADDR_TYPE_DOMAIN,
+        }
+    }
+}
+impl Socks5StreamBuilder {
+    pub fn new(address: SocketAddr) -> Self {
+        Self { address }
+    }
+    pub async fn connect<Stream: AsyncRead + AsyncWrite + Clone + Unpin>(
+        mut socket: Stream,
+        address: Socks5Addr,
+        port: u16,
+    ) -> Result<Stream, Socks5Error> {
+        socket
+            .write_all(&[SOCKS_VERSION, 1, SOCKS_AUTH_METHOD_NONE])
+            .await
+            .unwrap();
+        let address = match address {
+            Socks5Addr::Ipv4(addr) => addr.octets().to_vec(),
+            Socks5Addr::Ipv6(addr) => addr.octets().to_vec(),
+            Socks5Addr::Domain(domain) => {
+                let mut buf = vec![domain.len() as u8];
+                buf.extend_from_slice(domain.as_bytes());
+                buf
+            }
+        };
+        let mut buf = [0_u8; 2];
+        socket.read_exact(&mut buf).await?;
+
+        if buf[0] != SOCKS_VERSION {
+            return Err(Socks5Error::InvalidVersion);
+        }
+
+        if buf[1] != SOCKS_AUTH_METHOD_NONE {
+            return Err(Socks5Error::InvalidAuthMethod);
+        }
+
+        socket
+            .write_all(&[SOCKS_VERSION, SOCKS_CMD_CONNECT, 0, SOCKS_ADDR_TYPE_IPV4])
+            .await?;
+        socket.write_all(&address).await?;
+        socket.write_all(&port.to_be_bytes()).await?;
+
+        let mut buf = [0_u8; 4];
+        socket.read_exact(&mut buf).await?;
+
+        if buf[0] != SOCKS_VERSION {
+            return Err(Socks5Error::InvalidVersion);
+        }
+        if buf[1] != 0 {
+            return Err(Socks5Error::ConnectionFailed);
+        }
+
+        match buf[3] {
+            SOCKS_ADDR_TYPE_IPV4 => {
+                let mut buf = [0_u8; 6];
+                socket.read_exact(&mut buf).await?;
+            }
+            SOCKS_ADDR_TYPE_IPV6 => {
+                let mut buf = [0_u8; 18];
+                socket.read_exact(&mut buf).await?;
+            }
+            SOCKS_ADDR_TYPE_DOMAIN => {
+                let mut buf = [0_u8; 1];
+                socket.read_exact(&mut buf).await?;
+                let mut buf = vec![0_u8; buf[0] as usize + 2];
+                socket.read_exact(&mut buf).await?;
+            }
+            _ => return Err(Socks5Error::ConnectionFailed),
+        }
+        Ok(socket)
+    }
+}
+#[derive(Debug)]
+pub enum Socks5Error {
+    InvalidVersion,
+    InvalidAuthMethod,
+    ConnectionFailed,
+    ReadError(futures::io::Error),
+}
+
+impl From<futures::io::Error> for Socks5Error {
+    fn from(error: futures::io::Error) -> Self {
+        Socks5Error::ReadError(error)
+    }
+}

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -55,6 +55,7 @@ async fn main() {
         Arc::new(RwLock::new(Mempool::new())),
         Network::Bitcoin,
         DATA_DIR.into(),
+        None,
     );
     // A handle is a simple way to interact with the node. It implements a queue of requests
     // that will be processed by the node.

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -74,10 +74,14 @@ pub enum Commands {
     },
     #[cfg(feature = "experimental-p2p")]
     /// Starts your wallet and server
+    #[command(author, version, about, long_about = None)]
     Run {
         /// Where should we store data
         #[arg(long)]
         data_dir: Option<String>,
+        #[arg(long, short, default_value = None)]
+        /// The url of a proxy we should open p2p connections through (e.g. 127.0.0.1:9050)
+        proxy: Option<String>,
         #[arg(long, short, default_value = None)]
         rescan: Option<u32>,
         /// Add a xpub to our wallet

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -173,6 +173,7 @@ fn main() {
             wallet_xpub,
             wallet_descriptor,
             rescan,
+            proxy,
         } => {
             let kill_signal = Arc::new(RwLock::new(false));
 
@@ -228,6 +229,7 @@ fn main() {
                 Arc::new(async_std::sync::RwLock::new(Mempool::new())),
                 get_net(&params.network).into(),
                 data_dir,
+                proxy.map(|x| x.parse().expect("Invalid proxy address")),
             );
             info!("Starting server");
             let wallet = Arc::new(RwLock::new(wallet));


### PR DESCRIPTION
Up to now, peers would only use TcpSockets for connecting with others. But it would be nice if we can use other transports, like a SOCKS proxy or [Tor's Arti](https://tpo.pages.torproject.net/core/doc/rust/arti_client/index.html). This WIP refactors `Peer` to accept any transport.