### PR TITLE
WIP: Rework block notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "bitcoin 0.29.2",
  "miniscript 9.0.0",
  "sha2",
+ "spin",
 ]
 
 [[package]]

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 sha2 = "^0.10.6"
 bitcoin = "0.29.2"
 miniscript = { git = "https://github.com/douglaz/rust-miniscript.git", optional = true, branch = "master-2023-03-30" }
+spin = "0.9.8"
 
 [features]
 default = ["descriptors"]

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -7,6 +7,9 @@ use prelude::*;
 
 use sha2::Digest;
 pub mod constants;
+pub mod spsc;
+
+pub use spsc::Channel;
 
 pub fn get_hash_from_u8(data: &[u8]) -> sha256::Hash {
     let hash = sha2::Sha256::new().chain_update(data).finalize();
@@ -19,6 +22,7 @@ pub fn get_spk_hash(spk: &Script) -> sha256::Hash {
     hash.reverse();
     sha256::Hash::from_slice(hash.as_slice()).expect("Engines shouldn't be Err")
 }
+
 #[cfg(feature = "descriptors")]
 pub fn parse_descriptors(
     descriptors: &[String],

--- a/crates/floresta-common/src/spsc.rs
+++ b/crates/floresta-common/src/spsc.rs
@@ -1,0 +1,104 @@
+//! A no-std Single Producer, Single Consumer channel for unidirectional message exchange between
+//! modules. This module don't use anything from the standard lib and can be easily used in no-std
+//! enviroments. We only use mem::take from [core].
+
+use crate::prelude::Vec;
+use core::mem::take;
+
+/// A (Send + Sync) single producer, single consumer channel to notify modules about things.
+/// The api is super minimalistic to reduce external dependecies, including from the std-lib
+///
+/// One notable difference from the standard mspc channel is that this channel's ends are't
+/// two different types, while this is possible, there's no reason to do that. Specially
+/// considering that to get a good compile-time asurance that both ends will not be shared, the
+/// channel must not be [Send], but this is one of the main requirements to use this channel in
+/// async code. Moreover, if two worker threads are meant to be identical threads balancing their
+/// work, it might be beneficial to use this same channel as a de-facto single producer, multiple
+/// consumer channel for work distribution.
+/// # Example
+/// ```
+/// use floresta_common::spsc;
+/// let channel = spsc::Channel::new();
+///
+/// // Send something
+/// channel.send(1);
+/// // Read the same thing back
+/// assert_eq!(channel.recv().next(), Some(1));
+/// ```
+#[derive(Debug, Default)]
+pub struct Channel<T> {
+    /// The data pending for read
+    content: spin::Mutex<Vec<T>>,
+}
+
+impl<T> Channel<T> {
+    /// Creates a new channel
+    ///
+    /// # Example
+    /// ```
+    /// use floresta_common::spsc;
+    /// let channel = spsc::Channel::new();
+    ///
+    /// channel.send(1);
+    /// assert_eq!(channel.recv().next(), Some(1));
+    /// ```
+    pub fn new() -> Self {
+        Channel {
+            content: spin::Mutex::new(Vec::new()),
+        }
+    }
+    /// Sends some data through a channel
+    ///
+    /// # Example
+    /// ```
+    /// use floresta_common::spsc;
+    /// let channel = spsc::Channel::new();
+    ///
+    /// channel.send(1);
+    /// assert_eq!(channel.recv().next(), Some(1));
+    /// ```
+    pub fn send(&self, data: T) {
+        self.content.lock().push(data);
+    }
+    /// Reads from a channel
+    ///
+    /// This method returns an iterator over all alements inside a [Channel]
+    pub fn recv(&self) -> RecvIter<T> {
+        let inner = take(&mut *self.content.lock());
+        RecvIter { inner }
+    }
+}
+
+/// An iterator issued every time someone calls `recv`.
+///
+/// This iterator takes all itens available for reading in a channel
+/// and lets the consumer iterate over them, without acquiring the lock
+/// every time (the mutex is only locked when `recv` is called).
+///
+/// # Example
+/// ```
+/// use floresta_common::spsc;
+/// let channel = spsc::Channel::new();
+///
+/// channel.send(0);
+/// channel.send(1);
+///
+/// for (i, el) in channel.recv().enumerate() {
+///     assert_eq!(i, el);
+/// }
+/// // A second read should create an empty iterator
+/// assert_eq!(channel.recv().next(), None);
+/// ```
+pub struct RecvIter<T> {
+    inner: Vec<T>,
+}
+
+impl<T> Iterator for RecvIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.inner.is_empty() {
+            return None;
+        }
+        Some(self.inner.remove(0))
+    }
+}


### PR DESCRIPTION
Currently, if a module wants to get blocks as they are accepted, they should pass in a channel to `chainstate` and pool this channel for new blocks. That works fine for services (i.e: modules that have a loop watching stuff happening) but some modules might not be services, like the filters backend introduced in #89. This PR changes the subscription logic to "pass in an Arc-ed object that implements `BlockConsumer`".

It also implements a `Sync + Send + 'static` channel that depends solely on `alloc`, and implements `BlockConsumer`. The `std` `mspc` channel receiver isn't `Send`, making it tricky to use it across `await` points; using channels from `async-std::channel` adds the function coloring problem to the notification mechanism, which is undesirable. Moreover, we only need to send data from one source (`ChainState`) to one consumer  (whoever wants to be notified), therefore a single source, single consumer channel is a perfect fit.