### PR TITLE
Bugfix: recover from utreexo nodes hangup

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -170,7 +170,6 @@ impl ChainStore for KvChainStore {
         // Flush the default bucket with meta-info
         let bucket = self.0.bucket::<&[u8], Vec<u8>>(None)?;
         bucket.flush()?;
-
         Ok(())
     }
     fn save_header(&self, header: &DiskBlockHeader) -> Result<(), Self::Error> {


### PR DESCRIPTION
If all our utreexo connections are lost, and we take too long to recover, we might download blocks out-of-order and mess our acc up. This commit makes sure blocks are accepted in only in order.