### PR TITLE
don't ban on the first violation

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -114,12 +114,17 @@ impl Debug for Peer<TcpStream> {
         Ok(())
     }
 }
+
 type Result<T> = std::result::Result<T, PeerError>;
 
 impl<T: Transport> Peer<T> {
     pub async fn read_loop(mut self) -> Result<()> {
         let err = self.peer_loop_inner().await;
-        warn!("Peer connection loop closed: {err:?}");
+
+        if let Err(err) = err {
+            warn!("Peer {} connection loop closed: {err:?}", self.id);
+        }
+
         self.send_to_node(PeerMessages::Disconnected(self.address_id))
             .await;
         Ok(())

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -60,6 +60,7 @@ async fn main() {
         Network::Bitcoin,
         DATA_DIR.into(),
         None,
+        None,
     );
     // A handle is a simple way to interact with the node. It implements a queue of requests
     // that will be processed by the node.

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -254,6 +254,7 @@ fn run_with_ctx(ctx: Ctx) {
         get_net(&ctx.network).into(),
         data_dir,
         ctx.proxy.map(|x| x.parse().expect("Invalid proxy address")),
+        None,
     );
 
     // ZMQ


### PR DESCRIPTION
Banning a peer at the first time they misbehave (e.g. timeout a request) might be overaggressive, and lead to us being depleted of utreexo peers.

This commit adds a banscore system. Every time a peer misbehaves we increase that score. If it reaches a certain value, we ban them.