### PR TITLE
Implement tagged hashes for the leafhashes

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -31,6 +31,16 @@ use super::error::BlockchainError;
 /// The value of a single coin in satoshis.
 pub const COIN_VALUE: u64 = 100_000_000;
 
+/// The version tag to be prepended to the leafhash. It's just the sha512 hash of the string
+/// `UtreexoV1` represented as a vector of [u8] ([85 116 114 101 101 120 111 86 49]).
+/// The same tag is "5574726565786f5631" as a hex string.
+pub const UTREEXO_TAG_V1: [u8; 64] = [
+    0x5b, 0x83, 0x2d, 0xb8, 0xca, 0x26, 0xc2, 0x5b, 0xe1, 0xc5, 0x42, 0xd6, 0xcc, 0xed, 0xdd, 0xa8,
+    0xc1, 0x45, 0x61, 0x5c, 0xff, 0x5c, 0x35, 0x72, 0x7f, 0xb3, 0x46, 0x26, 0x10, 0x80, 0x7e, 0x20,
+    0xae, 0x53, 0x4d, 0xc3, 0xf6, 0x42, 0x99, 0x19, 0x99, 0x31, 0x77, 0x2e, 0x03, 0x78, 0x7d, 0x18,
+    0x15, 0x6e, 0xb3, 0x15, 0x1e, 0x0e, 0xd1, 0xb3, 0x09, 0x8b, 0xdc, 0x84, 0x45, 0x86, 0x18, 0x85,
+];
+
 /// This struct contains all the information and methods needed to validate a block,
 /// it is used by the [ChainState] to validate blocks and transactions.
 #[derive(Debug, Clone)]
@@ -75,6 +85,8 @@ impl Consensus {
         };
 
         let leaf_hash = Sha512_256::new()
+            .chain_update(UTREEXO_TAG_V1)
+            .chain_update(UTREEXO_TAG_V1)
             .chain_update(block_hash)
             .chain_update(transaction.txid())
             .chain_update(vout.to_le_bytes())

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -345,9 +345,9 @@ mod tests {
         }
         // The state after 100 blocks, computed ahead of time.
         let roots = [
-            "52a2ca409852acda9e194fbf2d8d9b10159bb4cee56248b3f3affdceaa294865",
-            "87b871d9c268eca95114929d619cf23399371248d350dc88e91ca33074341faf",
-            "480563375e4013e5ac1238fe0d85f8d997d93f626a0772ad76be6900f85b66c3",
+            "a2f1e6db842e13c7480c8d80f29ca2db5f9b96e1b428ebfdbd389676d7619081",
+            "b21aae30bc74e9aef600a5d507ef27d799b9b6ba08e514656d34d717bdb569d2",
+            "bedb648c9a3c5741660f926c1552d83ebb4cb1842cca6855b6d1089bb4951ce1",
         ]
         .iter()
         .map(|hash| NodeHash::from_str(hash).unwrap())
@@ -382,10 +382,10 @@ mod tests {
         }
 
         let roots = [
-            "f5fbbfca687f84f363a790ac26953bbc541e8864987a788083511c5dd5adae87",
-            "062221add29798889f62519b8b1de3ffb19b1349baea730a07aec8c6eaacb4e9",
-            "9f5cc264618d85b719a1738cdf3169355aac7033ff24f56361db34dfb9e6bbfd",
-            "350686755287afe78c33a27b187d83df1cd3c99ea93f4dd66781ecdedcc7d5b2",
+            "e00b4ecc7c30865af0ac3b0c7c1b996015f51d6a6577ee6f52cc04b55933eb91",
+            "9bf9659f93e246e0431e228032cd4b3a4d8a13e57f3e08a221e61f3e0bae657f",
+            "e329a7ddcc888130bb6e4f82ce9f5cf5a712a7b0ae05a1aaf21b363866a9b05e",
+            "1864a4982532447dcb3d9a5d2fea9f8ed4e3b1e759d55b8a427fb599fed0c302",
         ]
         .iter()
         .map(|x| NodeHash::from(hex::decode(x).unwrap().as_slice()))

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -12,6 +12,7 @@ use sha2::Digest;
 use sha2::Sha512_256;
 
 use crate::prelude::*;
+use crate::pruned_utreexo::consensus::UTREEXO_TAG_V1;
 /// Leaf data is the data that is hashed when adding to utreexo state. It contains validation
 /// data and some commitments to make it harder to attack an utreexo-only node.
 #[derive(Debug, PartialEq)]
@@ -39,6 +40,8 @@ impl LeafData {
         let mut ser_utxo = Vec::new();
         let _ = self.utxo.consensus_encode(&mut ser_utxo);
         let leaf_hash = Sha512_256::new()
+            .chain_update(UTREEXO_TAG_V1)
+            .chain_update(UTREEXO_TAG_V1)
             .chain_update(self.block_hash)
             .chain_update(self.prevout.txid)
             .chain_update(self.prevout.vout.to_le_bytes())


### PR DESCRIPTION
For versioning purposes, we want to prepend the preimage with a tag. There's more efficient ways to do this but that requires modifying rust-bitcoin and this is just the most straightforward way to implement tagged hashes.