### PR TITLE
Improve reindex_chain readability and small fixes

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -113,7 +113,7 @@ impl Consensus {
         subsidy: u64,
         verify_script: bool,
         flags: c_uint,
-    ) -> Result<bool, BlockchainError> {
+    ) -> Result<(), BlockchainError> {
         // Blocks must contain at least one transaction
         if transactions.is_empty() {
             return Err(BlockValidationErrors::EmptyBlock.into());
@@ -167,7 +167,7 @@ impl Consensus {
         {
             return Err(BlockValidationErrors::BadCoinbaseOutValue.into());
         }
-        Ok(true)
+        Ok(())
     }
     /// Calculates the next target for the proof of work algorithm, given the
     /// current target and the time it took to mine the last 2016 blocks.

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -204,18 +204,7 @@ impl PartialChainState {
         let flags = self.get_validation_flags(height);
         #[cfg(not(feature = "bitcoinconsensus"))]
         let flags = 0;
-        let valid = Consensus::verify_block_transactions(
-            inputs,
-            &block.txdata,
-            subsidy,
-            verify_script,
-            flags,
-        )?;
-        if !valid {
-            return Err(BlockchainError::BlockValidation(
-                BlockValidationErrors::InvalidTx(String::from("invalid block transactions")),
-            ));
-        }
+        Consensus::verify_block_transactions(inputs, &block.txdata, subsidy, verify_script, flags)?;
         Ok(())
     }
 }


### PR DESCRIPTION
A few suggested changes:
1. Better readability for `reindex_chain`
2. It seems that `maybe_reorg` is saving the branch tip with its parent height, so I add 1
3. `accept_header` should perhaps return if there's a database error
4. `verify_block_transactions` should just return `Ok(())`, instead of `Ok(true)`, since any other outcome is returned as `Err`

I also found an issue in `validate_block`:
We check if `block.header.prev_blockhash != prev_block.block_hash()`. But `prev_block` is fetched with `header.prev_blockhash`, so this check always passes! I don't know what is the desired behavior here.