### PR TITLE
Return when there's a tx validation error

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -747,12 +747,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let flags = self.get_validation_flags(height);
         #[cfg(not(feature = "bitcoinconsensus"))]
         let flags = 0;
-        Consensus::verify_block_transactions(inputs, &block.txdata, subsidy, verify_script, flags)
-            .map_err(|err| {
-                BlockchainError::BlockValidation(BlockValidationErrors::InvalidTx(alloc::format!(
-                    "{:?}", err
-                )))
-            })?;
+        Consensus::verify_block_transactions(inputs, &block.txdata, subsidy, verify_script, flags)?;
         Ok(())
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -3,6 +3,8 @@
 //! assume anything about the chainstate, so it can be used in any context.
 //! We use this to avoid code reuse among the different implementations of the chainstate.
 
+extern crate alloc;
+
 use core::ffi::c_uint;
 use core::ops::Mul;
 
@@ -151,7 +153,9 @@ impl Consensus {
             // Verify the tx script
             #[cfg(feature = "bitcoinconsensus")]
             if verify_script {
-                transaction.verify_with_flags(|outpoint| utxos.remove(outpoint), flags);
+                transaction
+                    .verify_with_flags(|outpoint| utxos.remove(outpoint), flags)
+                    .map_err(|err| BlockValidationErrors::InvalidTx(alloc::format!("{:?}", err)))?;
             }
         }
         // In each block, the first transaction, and only the first, should be coinbase


### PR DESCRIPTION
I believe the other `BlockValidationErrors` in `verify_block_transactions` should be returned as they are, and use `InvalidTx` only to return a specific transaction validation error.