### PR TITLE
Add AssumeValidArg enum and correct verify_script

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state_builder.rs
@@ -19,7 +19,7 @@ pub struct ChainStateBuilder<PersistedState: ChainStore> {
     chainstore: Option<PersistedState>,
     ibd: bool,
     chain_params: Option<ChainParams>,
-    assume_valid: Option<(BlockHash, u32)>,
+    assume_valid: Option<BlockHash>,
     tip: Option<(BlockHash, u32)>,
     first: Option<BlockHeader>,
 }
@@ -73,7 +73,7 @@ impl<T: ChainStore> ChainStateBuilder<T> {
         self.chain_params = Some(chain_params);
         self
     }
-    pub fn with_assume_valid(mut self, assume_valid: (BlockHash, u32)) -> Self {
+    pub fn with_assume_valid(mut self, assume_valid: BlockHash) -> Self {
         self.assume_valid = Some(assume_valid);
         self
     }
@@ -102,7 +102,7 @@ impl<T: ChainStore> ChainStateBuilder<T> {
         let block = self.tip.unwrap_or((BlockHash::all_zeros(), 0));
         BestChain::from(block)
     }
-    pub fn assume_valid(&self) -> (BlockHash, u32) {
-        self.assume_valid.unwrap_or((BlockHash::all_zeros(), 0))
+    pub fn assume_valid(&self) -> Option<BlockHash> {
+        self.assume_valid
     }
 }

--- a/crates/floresta/examples/chainstate-builder.rs
+++ b/crates/floresta/examples/chainstate-builder.rs
@@ -43,7 +43,7 @@ async fn main() {
     // to validate the blockchain. If you set the chain height, you should update
     // the accumulator to the state of the blockchain at that height too.
     let _chain: ChainState<KvChainStore> = ChainStateBuilder::new()
-        .with_assume_valid((BlockHash::all_zeros(), 0))
+        .with_assume_valid(BlockHash::all_zeros())
         .with_chain_params(ChainParams::from(Network::Bitcoin))
         .with_tip(
             (genesis_block(bitcoin::Network::Bitcoin).block_hash(), 0),

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -16,6 +16,7 @@ use floresta::chain::KvChainStore;
 use floresta::chain::Network;
 use floresta::wire::mempool::Mempool;
 use floresta::wire::node::UtreexoNode;
+use floresta_chain::AssumeValidArg;
 use floresta_wire::node_interface::NodeMethods;
 use floresta_wire::running_node::RunningNode;
 
@@ -35,13 +36,13 @@ async fn main() {
     // and the headers chain. It will also validate new blocks and headers as we receive them.
     // The last parameter is the assume valid block. We assume that all blocks before this
     // one have valid signatures. This is a performance optimization, as we don't need to validate all
-    // signatures in the blockchain, just the ones after the assume valid block. We are givin a None
+    // signatures in the blockchain, just the ones after the assume valid block. We are giving a Disabled
     // value, so we will validate all signatures regardless.
     // We place the chain state in an Arc, so we can share it with other components.
     let chain = Arc::new(ChainState::<KvChainStore>::new(
         chain_store,
         Network::Bitcoin,
-        None,
+        AssumeValidArg::Disabled,
     ));
 
     // Create a new node. It will connect to the Bitcoin network and start downloading the blockchain.

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -44,6 +44,7 @@ use cli::Commands;
 use cli::FilterType;
 use config_file::ConfigFile;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
+use floresta_chain::AssumeValidArg;
 use floresta_chain::BlockchainError;
 use floresta_chain::ChainState;
 use floresta_chain::KvChainStore;
@@ -417,13 +418,16 @@ fn load_chain_state(
     assume_valid: Option<bitcoin::BlockHash>,
 ) -> ChainState<KvChainStore> {
     let db = KvChainStore::new(data_dir.to_string()).expect("Could not read db");
-    match ChainState::<KvChainStore>::load_chain_state(db, network.into(), assume_valid) {
+    let assume_valid_arg =
+        assume_valid.map_or(AssumeValidArg::Hardcoded, AssumeValidArg::UserInput);
+
+    match ChainState::<KvChainStore>::load_chain_state(db, network.into(), assume_valid_arg) {
         Ok(chainstate) => chainstate,
         Err(err) => match err {
             BlockchainError::ChainNotInitialized => {
                 let db = KvChainStore::new(data_dir.to_string()).expect("Could not read db");
 
-                ChainState::<KvChainStore>::new(db, network.into(), assume_valid)
+                ChainState::<KvChainStore>::new(db, network.into(), assume_valid_arg)
             }
             _ => unreachable!(),
         },


### PR DESCRIPTION
I have added the `AssumeValidArg` enum to make the disabled and hardcoded options explicit, as discussed in #126.

Also I have changed `verify_script` to check whether there's an assume-valid hash, and if so also check if the block is in the best chain (now, if it is forked we won't assume the scripts). We no longer use the `assume_valid` field height, as we directly fetch the disk header (in order to verify the state of the block).

Updated the two examples. In florestad/src/main.rs I add a temporary conversion to `AssumeValidArg`, in next changes we could modify slightly the Command enum such that the assume-valid argument has this type.