### PR TITLE
fixed adding florestad to path while building

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ and build with cargo build
 
 ```bash
 cargo build --release --bin florestad
-# Optionally, you can install it with
-cargo install --path .
+# Optionally, you can add florestad to the path with
+cargo install --path ./florestad
 ```
 
 ### Running


### PR DESCRIPTION
the README has the incorrect command for adding florestad to the path, previously it was -
```bash
cargo install --path .
```
which resulted into the below error : 
> found a virtual manifest at '{path}/Floresta/Cargo.toml' instead of a package manifest

the new command is - 
```
cargo install --path ./florestad
```
this makes sure that we are installing path from the correct directory and this command is run after executing the `cargo build --release --bin florestad`
