### PR TITLE
Standardize Error handling across all the crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,6 @@ dependencies = [
 name = "floresta-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bitcoin 0.31.0",
  "clap",
  "rand 0.8.5",
@@ -933,6 +932,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/floresta-cli/Cargo.toml
+++ b/crates/floresta-cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.0.29", features = ["derive"] }
 bitcoin = { version = "0.31", features = ["serde", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-anyhow = "1.0"
+thiserror = "1.0"
 reqwest = { version = "0.11.23", optional = true, features = ["blocking"] }
 
 [features]

--- a/crates/floresta-cli/src/error.rs
+++ b/crates/floresta-cli/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+use floresta_cli::rpc_types::Error as RpcError;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Invalid network specified")]
+    InvalidNetwork,
+    #[error("RPC client error: {0}")]
+    CustomRpcError(#[from] reqwest::Error),
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+    #[error("Floresta RPC error: {0}")]
+    FlorestaRpcError(#[from] floresta_cli::rpc_types::Error),
+    #[error("Internal API error: {0}")]
+    ApiError(String),
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(error: serde_json::Error) -> Self {
+        AppError::SerializationError(error)
+    }
+}
+impl From<RpcError> for AppError {
+    fn from(error: RpcError) -> Self {
+        AppError::FlorestaRpcError(error)
+    }
+}

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -1,19 +1,20 @@
 use std::fmt::Debug;
 
-use anyhow::Ok;
 use bitcoin::BlockHash;
 use bitcoin::Network;
 use bitcoin::Txid;
 use clap::Parser;
 use clap::Subcommand;
+use crate::error::AppError;
 use floresta_cli::reqwest_client::ReqwestClient;
 use floresta_cli::rpc::FlorestaRPC;
 
+mod error;
 mod reqwest_client;
 mod rpc;
 mod rpc_types;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), AppError> {
     let cli = Cli::parse();
 
     let client = ReqwestClient::new(get_host(&cli));
@@ -21,7 +22,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("{}", res);
 
-    anyhow::Ok(())
+    Ok(())
 }
 
 fn get_host(cmd: &Cli) -> String {
@@ -38,7 +39,7 @@ fn get_host(cmd: &Cli) -> String {
     }
 }
 
-fn do_request(cmd: &Cli, client: ReqwestClient) -> anyhow::Result<String> {
+fn do_request(cmd: &Cli, client: ReqwestClient) -> Result<String, AppError> {
     Ok(match cmd.methods.clone() {
         Methods::GetBlockchainInfo => serde_json::to_string_pretty(&client.get_blockchain_info()?)?,
         Methods::GetBlockHash { height } => {

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -1,3 +1,4 @@
+use crate::error::AppError;
 use std::fmt::Display;
 
 use serde::Deserialize;
@@ -271,6 +272,18 @@ impl From<serde_json::Error> for Error {
 impl From<reqwest::Error> for Error {
     fn from(value: reqwest::Error) -> Self {
         Error::Reqwest(value)
+    }
+}
+
+impl From<Error> for AppError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::Serde(e) => AppError::SerializationError(e),
+            #[cfg(feature = "with-reqwest")]
+            Error::Reqwest(e) => AppError::CustomRpcError(e),
+            Error::Api(e) => AppError::ApiError(format!("{}", e)),
+            Error::EmtpyResponse => AppError::ApiError("Empty response from server".to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
`closes` #86 
This PR aims to standardize the error handling across all the crates mentioned in the comment  https://github.com/Davidson-Souza/Floresta/issues/86#issuecomment-1822268886 (and more, if found).
- [ ] BlockchainError
- [ ] Error
- [ ] WireError
- [ ] PeerError
- [ ] BlockValidationErrors
- [ ] KvDatabaseError
- [ ] WatchOnlyError
- [ ] Socks5Error

As far as I have looked into this, there are various types of error handling in these crates.
The easiest ones being those which use `anyhow`, simple custom type errors. Here syntactical modifications and error type from `custom` to `thiserror` will do the job.
But, for the custom error types, we have to convert their types to `thiserror` type errors and then modify everything else(ie, function calls, error propagation, etc). The complications are even higher in cases where these custom error types are interconnected and one custom type gets converted to other custom forms (in the case of `WireError`, `PeerError`, `BlockchainError`).