### PR TITLE
electrum: new experimental electrum endpoints

### DIFF
--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -372,6 +372,10 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         let known_descs = self.database.descs_get()?;
         Ok(known_descs.contains(desc))
     }
+    /// Tells wheter an address is already cached
+    pub fn is_address_cached(&self, script_hash: &Hash) -> bool {
+        self.address_map.contains_key(script_hash)
+    }
     pub fn push_descriptor(&self, descriptor: &str) -> Result<(), WatchOnlyError<D::Error>> {
         Ok(self.database.desc_save(descriptor)?)
     }


### PR DESCRIPTION
Those endpoints aren't part of the upstream yet, but they improve the UX
 of floresta and other index-less electrum servers like EPS.
    
Floresta doesn't keep a full index of all addresses that ever received
sats, as this would take multiple GBs. As a result, users can't ask for
arbitrary addresses on-demand.
    
However, with BIP157 client-side filters we can rescan for and address
in a relatively efficient way. However, by BIP158 compact block
filters, we can't use the Electrum out-of-the-box because they index the
scriptpubkey, not script hashes like electrum does. With this endpoint,
rather than sending the scripthash, we send the actual scriptpubkey.
With the script, we can use BIP158 filters to find transactions
belonging to a given address.
    
The endpoints are just all endpoints from `blockchain.scripthash` but
taking a scriptpubkey rather than the script hash. They behave
identically otherwise.