### PR TITLE
Functional tests for Chain Selector Node in Floresta-wire.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "spin",
- "zstd",
+ "zstd 0.12.4",
 ]
 
 [[package]]
@@ -1016,6 +1016,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "toml 0.5.11",
+ "zstd 0.13.1",
 ]
 
 [[package]]
@@ -3473,7 +3474,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 6.0.6",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+dependencies = [
+ "zstd-safe 7.1.0",
 ]
 
 [[package]]
@@ -3483,6 +3493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -33,6 +33,7 @@ floresta-compact-filters = { path = "../floresta-compact-filters" }
 thiserror = "1.0"
 floresta-common = { path = "../floresta-common" }
 oneshot = "0.1.5"
+zstd = "0.13.1"
 
 [features]
 default = []

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -103,5 +103,6 @@ pub mod peer;
 pub mod running_node;
 pub mod socks;
 pub mod stream_reader;
+pub mod sync_node;
 #[cfg(test)]
 pub mod test_chain_selector;

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -144,7 +144,7 @@ pub struct NodeCommon<Chain: BlockchainInterface + UpdatableChainstate> {
     pub(crate) peer_by_service: HashMap<ServiceFlags, Vec<u32>>,
     pub(crate) peer_ids: Vec<u32>,
     pub(crate) peers: HashMap<u32, LocalPeerView>,
-    pub(crate) chain: Chain,
+    pub(crate) chain: Arc<Chain>,
     pub(crate) blocks: HashMap<BlockHash, (PeerId, UtreexoBlock)>,
     pub(crate) inflight: HashMap<InflightRequests, (u32, Instant)>,
     pub(crate) node_rx: Receiver<NodeNotification>,
@@ -192,7 +192,7 @@ where
 {
     pub fn new(
         config: UtreexoNodeConfig,
-        chain: Chain,
+        chain: Arc<Chain>,
         mempool: Arc<RwLock<Mempool>>,
         block_filters: Option<Arc<NetworkFilters<KvFilterStore>>>,
     ) -> Self {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -312,6 +312,7 @@ where
                 .chain
                 .get_partial_chain(startup_tip, end, Stump::default())
                 .unwrap();
+            let chain = Arc::new(chain);
 
             let mut backfill = UtreexoNode::<SyncNode, PartialChainState>::new(
                 self.config.clone(),

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -45,6 +45,7 @@ async fn main() {
         Network::Bitcoin,
         AssumeValidArg::Disabled,
     ));
+    let chain = Arc::new(chain);
 
     // Create a new node. It will connect to the Bitcoin network and start downloading the blockchain.
     // It will also start a mempool, which will keep track of the current mempool state, this


### PR DESCRIPTION
## Changes made: 

* #### ``test_chain_selector.rs``: Rafactored the code in ``test_chain_selector`` for multiple peer interaction and a **lifetime** error which was occuring in `setup_test`.
* #### Changed the `chain` element in `NodeCommon` struct used in `UtreexoNode<ChainSelector, Chain>::new()` to be thread safe to be used multiple times after being moved in `setup_test` in `test_chain_selector`.
* #### ``chain_selector.rs``: Potential bug solved by extending the parameters given to `request_headers` function.