### PR TITLE
Potential bug fix in floresta-wire/chain_selector.rs

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -158,7 +158,7 @@ where
             }
         }
 
-        self.request_headers(headers.last().unwrap().block_hash())
+        self.request_headers(headers.last().unwrap().block_hash(), peer)
             .await
     }
 
@@ -546,12 +546,12 @@ where
     /// peer is following a chain with `tip` inside it. We use this in case some of
     /// our peer is in a fork, so we can learn about all blocks in that fork and
     /// compare the candidate chains to pick the best one.
-    async fn request_headers(&mut self, tip: BlockHash) -> Result<(), WireError> {
+    async fn request_headers(&mut self, tip: BlockHash, peer: PeerId) -> Result<(), WireError> {
         let locator = self
             .chain
             .get_block_locator_for_tip(tip)
             .unwrap_or_default();
-        self.send_to_peer(self.1.sync_peer, NodeRequest::GetHeaders(locator))
+        self.send_to_peer(peer, NodeRequest::GetHeaders(locator))
             .await?;
 
         let peer = self.1.sync_peer;
@@ -622,7 +622,10 @@ where
                     let new_sync_peer = rand::random::<usize>() % self.peer_ids.len();
                     self.1.sync_peer = *self.peer_ids.get(new_sync_peer).unwrap();
 
-                    try_and_log!(self.request_headers(self.chain.get_best_block()?.1).await);
+                    try_and_log!(
+                        self.request_headers(self.chain.get_best_block()?.1, self.1.sync_peer)
+                            .await
+                    );
 
                     self.1.state = ChainSelectorState::DownloadingHeaders;
                 }


### PR DESCRIPTION
Extended the parameters of `request_headers` function, by mentioning the `peer_id` of the peer to which the `GetHeaders` req is being sent to. 

Previously when `request_headers` function was called it was always sending req to `node.sync_peer`. 