### PR TITLE
bug fix: remove inflights of banned peers

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -753,7 +753,7 @@ where
                     if peer == self.1.sync_peer {
                         self.1.state = ChainSelectorState::CreatingConnections;
                     }
-                    self.handle_disconnection(peer, idx)?;
+                    self.handle_disconnection(peer, idx).await?;
                 }
 
                 PeerMessages::Addr(addresses) => {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -800,7 +800,7 @@ where
                     self.handle_peer_ready(peer, &version).await?;
                 }
                 PeerMessages::Disconnected(idx) => {
-                    self.handle_disconnection(peer, idx)?;
+                    self.handle_disconnection(peer, idx).await?;
                 }
                 PeerMessages::Addr(addresses) => {
                     debug!("Got {} addresses from peer {}", addresses.len(), peer);


### PR DESCRIPTION
When we ban a peer, we also have to remove the inflight requests related to that peer and send those to a random_peer.