### PR TITLE
cfilters: let user pick an initial height

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1018,6 +1018,7 @@ mod test {
             max_inflight: 20,
             assume_utreexo: None,
             backfill: false,
+            filter_start_height: None,
         };
 
         let chain_provider: UtreexoNode<RunningNode, Arc<ChainState<KvChainStore>>> =

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -55,6 +55,15 @@ pub struct UtreexoNodeConfig {
     /// is that we are vulnerable to a fraud proof attack for a few hours, but we can spot it
     /// and react in a couple of hours at most, so the attack window is very small.
     pub backfill: bool,
+    /// If we are using network-provided block filters, we may not need to download the whole
+    /// chain of filters, as our wallets may not have been created at the beginning of the chain.
+    /// With this option, we can make a rough estimate of the block height we need to start
+    /// and only download the filters from that height.
+    ///
+    /// If the value is negative, it's relative to the current tip. For example, if the current
+    /// tip is at height 1000, and we set this value to -100, we will start downloading filters
+    /// from height 900.
+    pub filter_start_height: Option<i32>,
 }
 
 impl Default for UtreexoNodeConfig {
@@ -71,6 +80,7 @@ impl Default for UtreexoNodeConfig {
             proxy: None,
             backfill: false,
             assume_utreexo: None,
+            filter_start_height: None,
         }
     }
 }

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -138,5 +138,8 @@ pub enum Commands {
         rpc_address: Option<String>,
         #[arg(long)]
         electrum_address: Option<String>,
+        #[arg(long)]
+        /// Download block filters starting at this height. Negative numbers are relative to the current tip.
+        filters_start_height: Option<i32>,
     },
 }

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -107,6 +107,14 @@ pub struct Config {
     /// is very inefficient and resource/time consuming. But keep in mind that filters will take
     /// up disk space.
     pub cfilters: bool,
+    /// If we are using block filters, we may not need to download the whole chain of filters, as
+    /// our wallets may not have been created at the beginning of the chain. With this option, we
+    /// can make a rough estimate of the block height we need to start downloading filters.
+    ///
+    /// If the value is negative, it's relative to the current tip. For example, if the current tip
+    /// is at height 1000, and we set this value to -100, we will start downloading filters from
+    /// height 900.
+    pub filters_start_height: Option<i32>,
     #[cfg(feature = "zmq-server")]
     /// The address to listen to for our ZMQ server
     ///
@@ -335,6 +343,7 @@ impl Florestad {
             max_inflight: 20,
             assume_utreexo,
             backfill: false,
+            filter_start_height: self.config.filters_start_height,
         };
 
         // Chain Provider (p2p)

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -45,6 +45,7 @@ async fn main() {
             connect,
             rpc_address,
             electrum_address,
+            filters_start_height,
         }) => Config {
             debug: params.debug,
             data_dir,
@@ -65,6 +66,7 @@ async fn main() {
             log_to_file: true,
             log_to_stdout: true,
             assume_utreexo: true,
+            filters_start_height,
         },
 
         // We may have more commands here, like setup and dump wallet


### PR DESCRIPTION
if we download all filters on mainnet, that will take ~11GB of disk
  space. But it's unlikely that users will have UTXOs going all the
  way back to the first few blocks. This commit introduces a new option
  to only download filters after a given height.

  If the provided value is negative, we compute an offset from the
  current height